### PR TITLE
feat: simplify hotkeys

### DIFF
--- a/src/components/OmniBar.tsx
+++ b/src/components/OmniBar.tsx
@@ -548,20 +548,7 @@ const OmniBar = () => {
         event.preventDefault()
         navigate('/initial')
       },
-      '$mod+.': (event: Event) => {
-        event.preventDefault()
-        const selectedConnectionId = connectionStore.selectedConnection?.id
-        if (selectedConnectionId) {
-          navigate(`/models/${selectedConnectionId}`)
-        } else {
-          navigate('/models')
-        }
-      },
-      '$mod+;': (event: Event) => {
-        event.preventDefault()
-        navigate('/personas')
-      },
-      '$mod+m': (event: Event) => {
+      '$mod+b': (event: Event) => {
         event.preventDefault()
         settingStore.toggleSideBar()
       },

--- a/src/tests/components/Omnibar.test.tsx
+++ b/src/tests/components/Omnibar.test.tsx
@@ -10,8 +10,6 @@ import OmniBar from '~/components/OmniBar'
 import { settingStore } from '~/core/setting/SettingStore'
 import { chatStore } from '~/core/chat/ChatStore'
 import { focusStore } from '~/core/FocusStore'
-import { connectionStore } from '../../core/connection/ConnectionStore'
-import { setServerResponse } from '../msw'
 
 describe('OmniBar', () => {
   const navigate = vi.fn()
@@ -66,42 +64,10 @@ describe('OmniBar', () => {
       })
     })
 
-    test('registers Ctrl+. to navigate to model panel', async () => {
-      expect(navigate).not.toHaveBeenCalled()
-
-      await userEvent.keyboard('{Control>}{.}')
-
-      await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('/models')
-      })
-    })
-
-    test('registers Ctrl+. to navigate to selected model panel', async () => {
-      setServerResponse('https://api.openai.com/v1/models', {
-        data: [],
-      })
-
-      const selectedConnection = await connectionStore.addConnection('OpenAi')
-
-      await userEvent.keyboard('{Control>}{.}')
-
-      await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('/models/' + selectedConnection.id)
-      })
-    })
-
-    test('registers Ctrl+; to open persona menu', async () => {
-      await userEvent.keyboard('{Control>}{;}')
-
-      await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('/personas')
-      })
-    })
-
-    test('registers Ctrl+Shift+M to toggle sidebar', async () => {
+    test('registers Ctrl+B to toggle sidebar', async () => {
       expect(settingStore.setting.isSidebarOpen).toBe(true)
 
-      await userEvent.keyboard('{Control>}{M}')
+      await userEvent.keyboard('{Control>}{B}')
 
       expect(settingStore.setting.isSidebarOpen).toBe(false)
     })


### PR DESCRIPTION
Simplifying the hotkeys:
- remove CTRL+. to open Models, can change models more quickly via CTRK+K
- remove CTRL-; to open Personas, can change personas more quickly via CTRK+K
- use CTRL+B for sidebar instead of CTRL+M (more consistent with other tools, avoids minimize on MacOS)
