### PR TITLE
feat: use CTRL+B for sidebar

### DIFF
--- a/src/components/OmniBar.tsx
+++ b/src/components/OmniBar.tsx
@@ -561,7 +561,7 @@ const OmniBar = () => {
         event.preventDefault()
         navigate('/personas')
       },
-      '$mod+m': (event: Event) => {
+      '$mod+b': (event: Event) => {
         event.preventDefault()
         settingStore.toggleSideBar()
       },

--- a/src/tests/components/Omnibar.test.tsx
+++ b/src/tests/components/Omnibar.test.tsx
@@ -98,10 +98,10 @@ describe('OmniBar', () => {
       })
     })
 
-    test('registers Ctrl+Shift+M to toggle sidebar', async () => {
+    test('registers Ctrl+B to toggle sidebar', async () => {
       expect(settingStore.setting.isSidebarOpen).toBe(true)
 
-      await userEvent.keyboard('{Control>}{M}')
+      await userEvent.keyboard('{Control>}{B}')
 
       expect(settingStore.setting.isSidebarOpen).toBe(false)
     })


### PR DESCRIPTION
This replaces #41 to avoid merge/rebase issues.
Use CTRL+B for sidebar instead of CTRL+M (more consistent with other tools, avoids minimize on MacOS)