### PR TITLE
Update model factories and adds more tests around models

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -8,14 +8,14 @@ module.exports = {
       name: 'core-not-to-non-core-utils',
       comment: 'Core folder should not import from non utils folder',
       severity: 'error',
-      from: { path: '^src/core/' },
+      from: { path: '^src/core/(?!.*(factory|test)).*' },
       to: { pathNot: '^src/(core|utils)/', dependencyTypesNot: ['type-only'] },
     },
     {
       name: 'utils-not-to-another-folder',
       comment: 'Utils folder should not import from non utils folder',
       severity: 'error',
-      from: { path: '^src/utils/' },
+      from: { path: '^src/utils/(?!.*(factory|test)).*' },
       to: { pathNot: '^src/utils/', dependencyTypesNot: ['type-only'] },
     },
     {

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,12 @@
 yarn check-deps
-yarn test run
+
+echo "Running tests and coverage check..."
+
+yarn coverage
+
+if [ $? -ne 0 ]; then
+  echo "❌ Coverage check failed."
+  exit 1
+fi
+
+echo "✅ Tests and Coverage check passed."

--- a/src/core/BaseTable.ts
+++ b/src/core/BaseTable.ts
@@ -111,7 +111,7 @@ export abstract class BaseTable<
   }
 
   async put(entity: Output, { skipCache = false }: { skipCache?: boolean } = {}) {
-    console.log('data: ', entity, this.getModel().safeParse(entity).data)
+    // console.log('data: ', entity, this.getModel().safeParse(entity).data)
     await this.database.setItem(entity.id, this.getModel().safeParse(entity).data)
 
     if (skipCache) {

--- a/src/core/actor/ActorModel.factory.ts
+++ b/src/core/actor/ActorModel.factory.ts
@@ -1,22 +1,58 @@
 import { Factory } from 'fishery'
 import { generateMock } from '@anatine/zod-mock'
+import _ from 'lodash'
 
 import { ActorModel } from '~/core/actor/ActorModel'
 import { ActorViewModel } from '~/core/actor/ActorViewModel'
 import { actorStore } from '~/core/actor/ActorStore'
+import { ConnectionViewModelTypes } from '~/core/connection/viewModels'
+import { type ConnectionModel } from '~/core/connection/ConnectionModel'
 
-export const ActorModelFactory = Factory.define<ActorModel, null, ActorViewModel>(
-  ({ sequence, params, onCreate }) => {
-    onCreate(async actorModel => {
-      const actorViewModel = await actorStore.createActor(actorModel)
+import {
+  ConnectionModelFactory,
+  ConnectionFactoryOptions,
+} from '~/core/connection/ConnectionModel.factory'
 
-      return actorViewModel
-    })
+export type ActorConnectionOptions = ConnectionFactoryOptions & {
+  connection?: ConnectionViewModelTypes
+  connectionParams?: Partial<ConnectionModel>
+}
 
-    return {
-      ...generateMock(ActorModel),
-      ...params,
-      id: sequence.toString(),
+class ActorModelFactoryClass extends Factory<ActorModel, null, ActorViewModel> {
+  // if the connection has models we assign the model to the actor
+  withOptions({ connection, connectionParams, ...options }: ActorConnectionOptions) {
+    const { models, modelCount } = options
+
+    if (connection && (_.isEmpty(models) || modelCount === 0)) {
+      return this.params({ connectionId: connection.id })
     }
-  },
-)
+
+    // after making the actor, create a connection and update the id
+    return this.afterCreate(async actor => {
+      connection ||= await ConnectionModelFactory.withOptions(options).create({
+        ...connectionParams,
+        type: 'Ollama',
+      })
+
+      const [model] = connection.models
+
+      await actor.update({ connectionId: connection.id, modelId: model?.id })
+
+      return actor
+    })
+  }
+}
+
+export const ActorModelFactory = ActorModelFactoryClass.define(({ sequence, params, onCreate }) => {
+  onCreate(async actorModel => {
+    const actorViewModel = await actorStore.createActor(actorModel)
+
+    return actorViewModel
+  })
+
+  return {
+    ...generateMock(ActorModel),
+    ...params,
+    id: sequence.toString(),
+  }
+})

--- a/src/core/chat/ChatModel.factory.ts
+++ b/src/core/chat/ChatModel.factory.ts
@@ -5,35 +5,77 @@ import _ from 'lodash'
 import { ChatModel } from '~/core/chat/ChatModel'
 import { ChatViewModel } from '~/core/chat/ChatViewModel'
 import { chatStore } from '~/core/chat/ChatStore'
-import { ActorModelFactory } from '~/core/actor/ActorModel.factory'
+import { type ActorViewModel } from '~/core/actor/ActorViewModel'
+import { MessageModel } from '~/core/message/MessageModel'
 
-type ChatFactoryTransientParams = {
+import { ActorConnectionOptions, ActorModelFactory } from '~/core/actor/ActorModel.factory'
+import { MessageModelFactory } from '~/core/message/MessageModel.factory'
+
+type ChatFactoryOptions = ActorConnectionOptions & {
+  chatParams?: Partial<ChatModel>
+
+  actors?: ActorViewModel[]
   actorCount?: number
+
+  messages?: MessageModel[]
+  messageCount?: number
+}
+class ChatModelFactoryClass extends Factory<ChatModel, null, ChatViewModel> {
+  withOptions({
+    actors,
+    actorCount,
+    messages,
+    messageCount,
+    chatParams,
+    ...options
+  }: ChatFactoryOptions = {}) {
+    // if messages or actors is defined, set their ids
+    return (
+      this.params(chatParams || {})
+        // actors
+        .params({ actorIds: _.map(actors, 'id') })
+        .afterCreate(async chat => {
+          if (actors || !_.isNumber(actorCount)) return chat
+
+          // create actors and add the ids
+          actors = await ActorModelFactory.withOptions(options).createList(actorCount)
+
+          await chat.update({ actorIds: _.map(actors, 'id') })
+
+          return chat
+        })
+
+        // messages
+        .params({ messageIds: _.map(messages, 'id') })
+        .afterCreate(async chat => {
+          if (messages || !_.isNumber(messageCount)) return chat
+
+          // create messages and add the ids
+          messages = await MessageModelFactory.createList(messageCount)
+
+          await chat.update({ messageIds: _.map(messages, 'id') })
+          await chat.fetchMessages()
+
+          return chat
+        })
+    )
+  }
 }
 
-export const ChatModelFactory = Factory.define<
-  ChatModel,
-  ChatFactoryTransientParams,
-  ChatViewModel
->(({ sequence, params, onCreate, transientParams }) => {
+export const ChatModelFactory = ChatModelFactoryClass.define(({ sequence, params, onCreate }) => {
   onCreate(async chatModel => {
     const chatViewModel = await chatStore.createChat()
 
     await chatViewModel.update({ ...chatModel, id: chatViewModel.id })
-
-    const actors = await ActorModelFactory.createList(transientParams?.actorCount ?? 0, {
-      chatId: chatViewModel.id,
-    })
-
-    for (const actor of actors) {
-      await chatViewModel.addActor(actor)
-    }
 
     return chatViewModel
   })
 
   return {
     ...generateMock(ChatModel),
+    // do not generate fake ids
+    actorIds: [],
+    messageIds: [],
     ...params,
     id: sequence.toString(),
   }

--- a/src/core/connection/ConnectionModel.factory.ts
+++ b/src/core/connection/ConnectionModel.factory.ts
@@ -3,27 +3,66 @@ import _ from 'lodash'
 
 import { ConnectionModel } from '~/core/connection/ConnectionModel'
 import { connectionViewModelByType, ConnectionViewModelTypes } from '~/core/connection/viewModels'
+import { LanguageModelFactory } from '~/core/LanguageModel.factory'
+import { BaseModelTypes } from '~/core/connection/types'
 
-export const ConnectionModelFactory = Factory.define<
-  ConnectionModel,
-  null,
-  ConnectionViewModelTypes
->(({ sequence, onCreate, params }) => {
-  onCreate(connectionModel => {
-    const ConnectionViewModelClass = connectionViewModelByType[connectionModel.type]()
+import { setServerResponseForModels } from '~/tests/helpers/setServerResponseForModels'
+import { connectionStore } from '~/core/connection/ConnectionStore'
 
-    return ConnectionViewModelClass.toViewModel(connectionModel)
-  })
+export type ConnectionFactoryOptions = {
+  connectionParams?: Partial<ConnectionModel>
 
-  const ConnectionViewModelClass = params.type
-    ? connectionViewModelByType[params.type]()
-    : _.sample(connectionViewModelByType)!()
+  modelCount?: number
+  models?: BaseModelTypes[]
+  modelParams?: Partial<BaseModelTypes>
+}
 
-  const snapshot = ConnectionViewModelClass.getSnapshot()
-
-  return {
-    ...snapshot,
-    ...params,
-    id: sequence.toString(),
+export const addModelsToConnection = async (
+  connection: ConnectionViewModelTypes,
+  { models, modelCount, modelParams }: ConnectionFactoryOptions,
+) => {
+  if (_.isNumber(modelCount) || !models) {
+    models = LanguageModelFactory.withOptions({
+      modelType: connection.type,
+      modelParams,
+    }).buildList(modelCount ?? 1)
   }
-})
+
+  setServerResponseForModels(connection, models)
+  await connection.fetchLmModels()
+}
+
+class ConnectionModelFactoryClass extends Factory<ConnectionModel, null, ConnectionViewModelTypes> {
+  withOptions(options: ConnectionFactoryOptions = {}) {
+    return this.params(options.connectionParams || {}).afterCreate(async connection => {
+      await addModelsToConnection(connection, options)
+
+      return connection
+    })
+  }
+}
+
+export const ConnectionModelFactory = ConnectionModelFactoryClass.define(
+  ({ sequence, onCreate, params }) => {
+    onCreate(async connectionModel => {
+      const connectionViewModel = await connectionStore.addConnection(
+        connectionModel.type,
+        connectionModel,
+      )
+
+      return connectionViewModel
+    })
+
+    const ConnectionViewModelClass = params.type
+      ? connectionViewModelByType[params.type]()
+      : _.sample(connectionViewModelByType)!()
+
+    const snapshot = ConnectionViewModelClass.getSnapshot()
+
+    return {
+      ...snapshot,
+      ...params,
+      id: sequence.toString(),
+    }
+  },
+)

--- a/src/core/connection/types.ts
+++ b/src/core/connection/types.ts
@@ -1,3 +1,5 @@
+import { type ModelResponse } from 'ollama/browser'
+
 import { toOllamaModel } from '~/core/transformers/toOllamaModel'
 import { LanguageModelType } from '~/core/LanguageModel'
 import { ConnectionModel } from '~/core/connection/ConnectionModel'
@@ -31,5 +33,7 @@ export type LanguageModelTypes =
   | GeminiLanguageModel
 
 export type ConnectionTypes = ConnectionModel['type']
+
+export type BaseModelTypes = ModelResponse | IA1111Model | IOpenAiModel | IGeminiModel
 
 export type { BaseLanguageModel } from '~/core/LanguageModel'

--- a/src/core/message/MessageModel.factory.ts
+++ b/src/core/message/MessageModel.factory.ts
@@ -1,0 +1,21 @@
+import { Factory } from 'fishery'
+import { generateMock } from '@anatine/zod-mock'
+
+import { MessageModel } from '~/core/message/MessageModel'
+import { messageTable } from '~/core/message/MessageTable'
+
+class MessageModelFactoryClass extends Factory<MessageModel> {}
+
+export const MessageModelFactory = MessageModelFactoryClass.define(
+  ({ sequence, params, onCreate }) => {
+    onCreate(async messageModel => {
+      return messageTable.create(messageModel)
+    })
+
+    return {
+      ...generateMock(MessageModel),
+      ...params,
+      id: sequence.toString(),
+    }
+  },
+)

--- a/src/core/message/MessageViewModel.ts
+++ b/src/core/message/MessageViewModel.ts
@@ -77,7 +77,7 @@ export class MessageViewModel {
   isBlank() {
     if (!this.source) return true
 
-    return _.isEmpty(this.content || this.source.imageUrls || this.source.extras?.error)
+    return _.isEmpty(this.content || this.source.imageUrls[0] || this.source.extras?.error)
   }
 
   updateContent(content: string) {

--- a/src/tests/components/ModelAndPersonaDisplay.test.tsx
+++ b/src/tests/components/ModelAndPersonaDisplay.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import _ from 'lodash'
+
+import ModelAndPersonaDisplay from '~/components/ModelAndPersonaDisplay'
+import { ChatModelFactory } from '~/core/chat/ChatModel.factory'
+import { ActorModelFactory } from '~/core/actor/ActorModel.factory'
+
+describe('ModelAndPersonaDisplay', () => {
+  const expectModelButtonTextToEqual = async (text: string) => {
+    const buttons = await screen.findAllByRole('button')
+
+    expect(buttons[0].textContent).toEqual(text)
+  }
+
+  const expectPersonasButtonTextToEqual = async (text: string) => {
+    const buttons = await screen.findAllByRole('button')
+
+    expect(buttons[1].textContent).toEqual(text)
+  }
+
+  test('shows empty buttons when nothing is selected', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ModelAndPersonaDisplay />
+      </MemoryRouter>,
+    )
+
+    console.log(screen.debug())
+
+    await expectModelButtonTextToEqual('No models selected')
+    await expectPersonasButtonTextToEqual('No personas selected')
+  })
+
+  describe('chat actors', () => {
+    test('shows actor model name', async () => {
+      const chat = await ChatModelFactory.withOptions({ actorCount: 1 }).create()
+
+      const [actor] = chat.actors
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <ModelAndPersonaDisplay />
+        </MemoryRouter>,
+      )
+
+      await expectModelButtonTextToEqual('Model: ' + actor.label)
+      await expectPersonasButtonTextToEqual('No personas selected')
+    })
+
+    test('shows +x when multiple actors exist', async () => {
+      const otherActors = await ActorModelFactory.withOptions({
+        modelParams: {
+          name: 'Other Actor',
+        },
+
+        connectionParams: {
+          type: 'Ollama',
+        },
+      }).createList(4)
+
+      const actor = await ActorModelFactory.withOptions({
+        modelParams: {
+          name: 'First Actor',
+        },
+
+        connectionParams: {
+          type: 'Ollama',
+        },
+      }).create()
+
+      // add a connection, but its not active
+      await ChatModelFactory.withOptions({
+        actors: [actor, ...otherActors],
+      }).create()
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <ModelAndPersonaDisplay />
+        </MemoryRouter>,
+      )
+
+      await expectModelButtonTextToEqual('Model: First Actor +4')
+      await expectPersonasButtonTextToEqual('No personas selected')
+    })
+  })
+})

--- a/src/tests/components/ModelSelector.test.tsx
+++ b/src/tests/components/ModelSelector.test.tsx
@@ -8,11 +8,11 @@ import * as router from 'react-router'
 
 import ModelSelector from '~/components/ModelSelector'
 import { setServerResponse } from '~/tests/msw'
-import { OllamaModelFactory } from '~/core/LanguageModel.factory'
 import { connectionStore } from '~/core/connection/ConnectionStore'
 import { ConnectionViewModelTypes } from '~/core/connection/viewModels'
 import { LanguageModelTypes } from '~/core/connection/types'
 import { ChatModelFactory } from '~/core/chat/ChatModel.factory'
+import { ConnectionModelFactory } from '~/core/connection/ConnectionModel.factory'
 
 describe('ModelSelector', () => {
   const matchMediaMock = new MatchMediaMock()
@@ -72,13 +72,9 @@ describe('ModelSelector', () => {
       let selectedModel: LanguageModelTypes
 
       beforeEach(async () => {
-        setServerResponse('http://localhost:11434/api/tags', {
-          models: OllamaModelFactory.buildList(3),
-        })
-
-        selectedConnection = await connectionStore.addConnection('Ollama')
-
-        await selectedConnection.fetchLmModels()
+        selectedConnection = await ConnectionModelFactory.withOptions({
+          modelCount: 3,
+        }).create({ type: 'Ollama' })
 
         expect(selectedConnection.models.length).toBe(3)
 
@@ -128,7 +124,7 @@ describe('ModelSelector', () => {
       })
 
       test('displays actor length when actors are present', async () => {
-        await ChatModelFactory.create({}, { transient: { actorCount: 4 } })
+        await ChatModelFactory.withOptions({ actorCount: 4 }).create()
 
         const { container } = render(
           <MemoryRouter initialEntries={['/']}>
@@ -140,7 +136,7 @@ describe('ModelSelector', () => {
       })
 
       test('displays singular actor when only one actor present', async () => {
-        await ChatModelFactory.create({}, { transient: { actorCount: 1 } })
+        await ChatModelFactory.withOptions({ actorCount: 1 }).create()
 
         const { container } = render(
           <MemoryRouter initialEntries={['/']}>
@@ -203,7 +199,7 @@ describe('ModelSelector', () => {
       test('navigates to selected initial page on mobile', async () => {
         matchMediaMock.useMediaQuery('(max-width: 768px)')
 
-        await ChatModelFactory.create({}, { transient: { actorCount: 2 } })
+        await ChatModelFactory.withOptions({ actorCount: 2 }).create()
 
         render(
           <MemoryRouter initialEntries={['/']}>
@@ -223,7 +219,7 @@ describe('ModelSelector', () => {
       })
 
       test('navigates to selected chat', async () => {
-        const selectedChat = await ChatModelFactory.create({}, { transient: { actorCount: 2 } })
+        const selectedChat = await ChatModelFactory.withOptions({ actorCount: 2 }).create()
 
         render(
           <MemoryRouter initialEntries={['/']}>

--- a/src/tests/core/ActorViewModel.test.ts
+++ b/src/tests/core/ActorViewModel.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest'
+
+import { ActorViewModel } from '~/core/actor/ActorViewModel'
+import { actorTable } from '~/core/actor/ActorTable'
+import { actorStore } from '~/core/actor/ActorStore'
+import { ActorModelFactory } from '~/core/actor/ActorModel.factory'
+
+describe('ActorViewModel', () => {
+  let actor: ActorViewModel
+
+  beforeEach(async () => {
+    await actorTable.clearCacheAndPreload()
+
+    await ActorModelFactory.withOptions({ modelCount: 1 }).create()
+
+    actor = actorStore.actors[0]
+  })
+
+  afterEach(async () => {
+    await actorTable.clearCacheAndPreload()
+  })
+
+  test('connection returns a connection', () => {
+    expect(actor.connection).toBeDefined()
+    expect(actor.connection?.id).toBe(actor.source.connectionId)
+  })
+
+  test('model returns a model', () => {
+    expect(actor.model?.id).toBeDefined()
+    expect(actor.model?.id).toBe(actor.source.modelId)
+  })
+
+  test('modelName returns a string', () => {
+    expect(typeof actor.modelName).toBe('string')
+  })
+
+  test('isConnected returns true if model exists', async () => {
+    expect(actor.isConnected).toBe(true)
+
+    await actor.removeConnection()
+
+    expect(actor.isConnected).toBe(false)
+  })
+
+  test('update changes the actor', async () => {
+    await actor.update({ name: 'Updated Name' })
+
+    const updated = await actorTable.findById(actor.id)
+    expect(updated!.name).toBe('Updated Name')
+  })
+
+  test('removeConnection clears connectionId and modelId', async () => {
+    expect(actor.connection).toBeDefined()
+    await actor.removeConnection()
+
+    const updated = await actorTable.findById(actor.id)
+    expect(updated!.connectionId).toBeNull()
+    expect(updated!.modelId).toBeNull()
+  })
+})

--- a/src/tests/core/ChatViewModel.test.ts
+++ b/src/tests/core/ChatViewModel.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+import _ from 'lodash'
+
+import { messageTable } from '~/core/message/MessageTable'
+import { ChatModelFactory } from '~/core/chat/ChatModel.factory'
+
+describe('ChatViewModel', () => {
+  test('constructs with a ChatModel and exposes properties', async () => {
+    const chat = await ChatModelFactory.create({ name: 'Test Chat' })
+
+    expect(chat.name).toBe('Test Chat')
+    expect(chat.messages).toEqual([])
+    expect(chat.actors).toEqual([])
+  })
+
+  test('can add and fetch messages', async () => {
+    const message = await messageTable.create({ fromBot: false, content: 'Hello' })
+    const chat = await ChatModelFactory.withOptions({ messages: [message] }).create()
+
+    await chat.fetchMessages()
+
+    expect(chat.messages.length).toBe(1)
+    expect(chat.messages[0].content).toBe('Hello')
+  })
+
+  test('can add and remove actors', async () => {
+    const chat = await ChatModelFactory.withOptions({ modelCount: 1, actorCount: 1 }).create()
+
+    const [actor] = chat.actors
+
+    // Remove the actor
+    await chat.removeActorById(actor.id)
+    expect(chat.source.actorIds).not.toContain(actor.id)
+  })
+
+  test('can add a user message and update chat name', async () => {
+    const chat = await ChatModelFactory.create({ name: undefined })
+
+    await chat.addUserMessage('First message')
+    expect(chat.source.messageIds.length).toBe(1)
+
+    expect(chat.messages[0].content).toBe('First message')
+    // Name should be updated from default
+    expect(chat.source.name).toBe('First message')
+  })
+
+  test('can remove user messages', async () => {
+    const chat = await ChatModelFactory.withOptions({ messageCount: 3, actorCount: 0 }).create()
+
+    const [firstMessage, secondMessage, thirdMessage] = chat.messages
+
+    expect(chat.source.messageIds.length).toBe(3)
+
+    await chat.destroyMessage(secondMessage)
+
+    expect(chat.messages).toEqual([firstMessage, thirdMessage])
+  })
+})

--- a/src/tests/core/ConnectionViewModel.test.ts
+++ b/src/tests/core/ConnectionViewModel.test.ts
@@ -1,20 +1,18 @@
 import { describe, expect, test } from 'vitest'
-import { server, setServerResponse } from '~/tests/msw'
+import { server } from '~/tests/msw'
 import { http, HttpResponse } from 'msw'
 import _ from 'lodash'
 
 import { ConnectionModelFactory } from '~/core/connection/ConnectionModel.factory'
-import { OllamaModelFactory, OpenAiModelFactory } from '~/core/LanguageModel.factory'
+import { LanguageModelFactory } from '~/core/LanguageModel.factory'
 
 describe('ConnectionViewModel', () => {
   describe('OllamaConnectionViewModel', () => {
     test('is empty when nothing returns', async () => {
-      const connectionModel = await ConnectionModelFactory.create({
+      const connectionModel = await ConnectionModelFactory.withOptions({ models: [] }).create({
         type: 'Ollama',
         host: 'http://ollama-host:4444',
       })
-
-      setServerResponse('http://ollama-host:4444/api/tags', { models: [] })
 
       const emptyModels = await connectionModel.fetchLmModels()
 
@@ -23,16 +21,16 @@ describe('ConnectionViewModel', () => {
     })
 
     test('has models when models are returned', async () => {
-      const ollamaModels = OllamaModelFactory.buildList(3)
+      const ollamaModels = LanguageModelFactory.ollama().buildList(3)
 
-      const connectionModel = await ConnectionModelFactory.create({
+      const connectionModel = await ConnectionModelFactory.withOptions({
+        models: ollamaModels,
+      }).create({
         type: 'Ollama',
         host: 'http://ollama-host:4444',
       })
 
-      setServerResponse('http://ollama-host:4444/api/tags', { models: ollamaModels })
-
-      const models = _.toArray(await connectionModel.fetchLmModels())
+      const models = _.toArray(connectionModel.models)
       const modelNames = _.map(models, 'modelName')
 
       expect(models.length).toBe(3)
@@ -63,14 +61,12 @@ describe('ConnectionViewModel', () => {
     })
 
     test('clears models after fetch fails', async () => {
-      const ollamaModels = OllamaModelFactory.buildList(3)
-
-      const connectionModel = await ConnectionModelFactory.create({
+      const connectionModel = await ConnectionModelFactory.withOptions({
+        modelCount: 3,
+      }).create({
         type: 'Ollama',
         host: 'http://ollama-host:4444',
       })
-
-      setServerResponse('http://ollama-host:4444/api/tags', { models: ollamaModels })
 
       let models = _.toArray(await connectionModel.fetchLmModels())
 
@@ -92,12 +88,10 @@ describe('ConnectionViewModel', () => {
 
   describe('OpenAiConnectionViewModel', () => {
     test('is empty when nothing returns', async () => {
-      const connectionModel = await ConnectionModelFactory.create({
+      const connectionModel = await ConnectionModelFactory.withOptions({ models: [] }).create({
         type: 'OpenAi',
         host: 'http://openAi-host:4444/v1',
       })
-
-      setServerResponse('http://openAi-host:4444/v1/models', { data: [] })
 
       const emptyModels = await connectionModel.fetchLmModels()
 
@@ -106,14 +100,14 @@ describe('ConnectionViewModel', () => {
     })
 
     test('has models when models are returned', async () => {
-      const openAiModels = OpenAiModelFactory.buildList(3)
+      const openAiModels = LanguageModelFactory.openAi().buildList(3)
 
-      const connectionModel = await ConnectionModelFactory.create({
+      const connectionModel = await ConnectionModelFactory.withOptions({
+        models: openAiModels,
+      }).create({
         type: 'OpenAi',
         host: 'http://openAi-host:4444/v1',
       })
-
-      setServerResponse('http://openAi-host:4444/v1/models', { data: openAiModels })
 
       const models = _.toArray(await connectionModel.fetchLmModels())
       const modelNames = _.map(models, 'modelName')
@@ -146,14 +140,12 @@ describe('ConnectionViewModel', () => {
     })
 
     test('clears models after fetch fails', async () => {
-      const openAiModels = OpenAiModelFactory.buildList(3)
-
-      const connectionModel = await ConnectionModelFactory.create({
+      const connectionModel = await ConnectionModelFactory.withOptions({
+        modelCount: 3,
+      }).create({
         type: 'OpenAi',
         host: 'http://openAi-host:4444/v1',
       })
-
-      setServerResponse('http://openAi-host:4444/v1/models', { data: openAiModels })
 
       let models = _.toArray(await connectionModel.fetchLmModels())
 

--- a/src/tests/core/LanguageModel.test.ts
+++ b/src/tests/core/LanguageModel.test.ts
@@ -1,17 +1,16 @@
 import { describe, expect, test } from 'vitest'
-import {
-  A1111ModelFactory,
-  GeminiModelFactory,
-  OllamaModelFactory,
-  OpenAiModelFactory,
-} from '~/core/LanguageModel.factory'
+import { LanguageModelFactory } from '~/core/LanguageModel.factory'
 import LanguageModel from '~/core/LanguageModel'
+import { toOllamaModel } from '~/core/transformers/toOllamaModel'
 
 describe('LanguageModel', () => {
   test('should correctly format an ollama model', async () => {
-    const ollamaModelResponse = await OllamaModelFactory.create()
+    const ollamaModelResponse = LanguageModelFactory.buildOllama()
 
-    const ollamaModel = LanguageModel.fromIOllamaModel(ollamaModelResponse, 'ollama-connectionId')
+    const ollamaModel = LanguageModel.fromIOllamaModel(
+      toOllamaModel(ollamaModelResponse),
+      'ollama-connectionId',
+    )
 
     expect(ollamaModel.type).toBe('Ollama')
     expect(ollamaModel.id).toBe('ollama-connectionId:' + ollamaModelResponse.name)
@@ -22,7 +21,7 @@ describe('LanguageModel', () => {
   })
 
   test('should correctly format an openai model', async () => {
-    const openAiModelResponse = OpenAiModelFactory.build()
+    const openAiModelResponse = LanguageModelFactory.buildOpenAi()
 
     const ollamaModel = LanguageModel.fromIOpenAiModel(openAiModelResponse, 'openai-connectionId')
 
@@ -35,7 +34,7 @@ describe('LanguageModel', () => {
   })
 
   test('should correctly format an gemini model', async () => {
-    const geminiModelResponse = GeminiModelFactory.build()
+    const geminiModelResponse = LanguageModelFactory.buildGemini()
 
     const ollamaModel = LanguageModel.fromIGeminiModel(geminiModelResponse, 'gemini-connectionId')
 
@@ -48,7 +47,7 @@ describe('LanguageModel', () => {
   })
 
   test('should correctly format an a1111 model', async () => {
-    const a1111ModelResponse = A1111ModelFactory.build()
+    const a1111ModelResponse = LanguageModelFactory.buildA1111()
 
     const ollamaModel = LanguageModel.fromIA1111Model(a1111ModelResponse, 'a1111-connectionId')
 

--- a/src/tests/core/MessageViewModel.test.ts
+++ b/src/tests/core/MessageViewModel.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import _ from 'lodash'
+
+import { MessageModelFactory } from '~/core/message/MessageModel.factory'
+import { MessageViewModel } from '~/core/message/MessageViewModel'
+import { MessageModel } from '~/core/message/MessageModel'
+import { ChatModelFactory } from '~/core/chat/ChatModel.factory'
+import { messageTable } from '~/core/message/MessageTable'
+
+import * as FormatMessageDetailsFile from '~/utils/formatMessageDetails'
+
+describe('MessageViewModel', () => {
+  let viewModel: MessageViewModel
+  let messageModel: MessageModel
+
+  const resetViewModel = async () => {
+    const chat = await ChatModelFactory.create()
+
+    viewModel = await chat.createAndPushIncomingMessage()
+    messageModel = (await messageTable.findById(viewModel.id))!
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+
+    await resetViewModel()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('constructs with a MessageModel and exposes properties', () => {
+    expect(viewModel.content).toBe('')
+    expect(viewModel.variations).toEqual([])
+    expect(viewModel.selectedVariation).toBe(viewModel)
+    expect(viewModel.rootMessage).toBe(viewModel)
+  })
+
+  test('setShowVariations updates showVariations', () => {
+    viewModel.setShowVariations(true)
+    expect(viewModel.showVariations).toBe(true)
+  })
+
+  test('updateContent appends and updates content', async () => {
+    viewModel.updateContent('Hello')
+    viewModel.updateContent(' world')
+
+    expect(viewModel.content).toEqual('Hello world')
+
+    // has not updated the db yet
+    expect(messageModel?.content).toBe('')
+
+    // fast forward time
+    await vi.runAllTimersAsync()
+
+    expect(messageModel?.content).toEqual('Hello world')
+  })
+
+  test('isBlank returns false for non-empty content or image urls', async () => {
+    expect(viewModel.isBlank()).toBe(true)
+
+    viewModel.updateContent('anything')
+
+    // fast forward time
+    await vi.runAllTimersAsync()
+
+    expect(viewModel.isBlank()).toBe(false)
+
+    await resetViewModel()
+
+    await viewModel.addImages(['example image'])
+
+    expect(viewModel.isBlank()).toBe(false)
+
+    // TODO: fix isBlank for error messages
+    // await resetViewModel()
+
+    // await viewModel.setError(new Error('anything'))
+
+    // expect(viewModel.isBlank()).toBe(false)
+  })
+
+  test('setError updates extras with error', async () => {
+    await viewModel.setError(new Error('custom message'))
+    expect(messageModel.extras?.error?.message).toBe('custom message')
+  })
+
+  test('setExtraDetails updates extras with details', async () => {
+    vi.spyOn(FormatMessageDetailsFile, 'formatMessageDetails')
+
+    await viewModel.setExtraDetails({ foo: 'bar' })
+
+    expect(JSON.parse(messageModel.extras?.details || '')).toMatchObject({ foo: 'bar' })
+
+    expect(FormatMessageDetailsFile.formatMessageDetails).toHaveBeenCalledWith({ foo: 'bar' })
+  })
+
+  test('addImages updates imageUrls with message based url', async () => {
+    await viewModel.addImages(['example image'])
+
+    expect(messageModel.imageUrls[0]?.startsWith(`/llm-x/message/${viewModel.id}/`)).toBe(true)
+  })
+
+  test('addVariation and removeVariation update variations', async () => {
+    expect(viewModel.variations.length).toBe(0)
+
+    const variation = MessageModelFactory.build({ content: 'Variation', fromBot: false })
+    const variationViewModel = await viewModel.addVariation(variation)
+    expect(viewModel.variations.map(v => v.id)).toContain(variation.id)
+    await viewModel.removeVariation(variationViewModel)
+    expect(viewModel.variations.map(v => v.id)).not.toContain(variation.id)
+  })
+
+  test('setVariation and selectNextVariation/PreviousVariation', async () => {
+    const selectedVariationHandler = viewModel.selectedVariationHandler
+
+    // helper for less repeated test code
+    const expectVariationsToBe = (
+      previous: MessageViewModel | undefined,
+      current: MessageViewModel | undefined,
+      next: MessageViewModel | undefined,
+    ) => {
+      expect(selectedVariationHandler.previousVariation).toBe(previous)
+      expect(viewModel.selectedVariation).toBe(current)
+      expect(selectedVariationHandler.nextVariation).toBe(next)
+    }
+
+    // prepare messages
+    const variationModel1 = await MessageModelFactory.create()
+    const variationModel2 = await MessageModelFactory.create()
+
+    expectVariationsToBe(undefined, viewModel, undefined)
+
+    // add a new variation
+    const variation1 = await viewModel.addVariation(variationModel1)
+    expectVariationsToBe(viewModel, variation1, undefined)
+
+    // go back to original message
+    await viewModel.selectPreviousVariation()
+    expectVariationsToBe(undefined, viewModel, variation1)
+
+    // add another variation
+    const variation2 = await viewModel.addVariation(variationModel2)
+    expectVariationsToBe(variation1, variation2, undefined)
+
+    // go back to variation 1
+    await viewModel.selectPreviousVariation()
+    expectVariationsToBe(viewModel, variation1, variation2)
+
+    // go back to original message
+    await viewModel.selectPreviousVariation()
+    expectVariationsToBe(undefined, viewModel, variation1)
+
+    // sanity check
+    expect(variation1).not.toBe(variation2)
+  })
+})

--- a/src/tests/core/MessageViewModel.test.ts
+++ b/src/tests/core/MessageViewModel.test.ts
@@ -60,25 +60,24 @@ describe('MessageViewModel', () => {
   test('isBlank returns false for non-empty content or image urls', async () => {
     expect(viewModel.isBlank()).toBe(true)
 
+    // if there is content
     viewModel.updateContent('anything')
-
     // fast forward time
     await vi.runAllTimersAsync()
 
     expect(viewModel.isBlank()).toBe(false)
 
+    // if there are images
     await resetViewModel()
-
     await viewModel.addImages(['example image'])
 
     expect(viewModel.isBlank()).toBe(false)
 
-    // TODO: fix isBlank for error messages
-    // await resetViewModel()
+    // if there are errors
+    await resetViewModel()
+    await viewModel.setError(new Error('anything'))
 
-    // await viewModel.setError(new Error('anything'))
-
-    // expect(viewModel.isBlank()).toBe(false)
+    expect(viewModel.isBlank()).toBe(false)
   })
 
   test('setError updates extras with error', async () => {

--- a/src/tests/core/Setting.test.ts
+++ b/src/tests/core/Setting.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, beforeEach } from 'vitest'
+import _ from 'lodash'
+
+import { chatStore } from '~/core/chat/ChatStore'
+import { initDb } from '~/core/db'
+import { settingStore } from '~/core/setting/SettingStore'
+import { SettingModel } from '~/core/setting/SettingModel'
+import { ChatModelFactory } from '~/core/chat/ChatModel.factory'
+import { ChatViewModel } from '~/core/chat/ChatViewModel'
+import { ConnectionModelFactory } from '~/core/connection/ConnectionModel.factory'
+import { connectionStore } from '~/core/connection/ConnectionStore'
+
+describe('Setting', () => {
+  let setting: SettingModel
+
+  beforeEach(async () => {
+    await initDb()
+
+    setting = settingStore.setting
+  })
+
+  describe('Chat', () => {
+    let originalChat: ChatViewModel
+
+    beforeEach(async () => {
+      originalChat = chatStore.selectedChat!
+    })
+
+    test('exists after init', () => {
+      expect(originalChat.id).toBe(setting.selectedChatId)
+    })
+
+    test('updates when the id changes', async () => {
+      // make the chat not empty
+      await originalChat.addUserMessage('Message needed to create a new chat')
+
+      // create a new, empty chat
+      const nextChat = await ChatModelFactory.create()
+
+      expect(nextChat.id).not.toBe(originalChat.id)
+
+      //   see that the new chat is selected
+      expect(chatStore.selectedChat!.id).toEqual(nextChat.id)
+      expect(setting.selectedChatId).toEqual(nextChat.id)
+
+      await chatStore.selectChat(originalChat)
+
+      expect(chatStore.selectedChat).toBe(originalChat)
+      expect(setting.selectedChatId).toBe(originalChat.id)
+    })
+  })
+
+  describe('Connection', () => {
+    test('does not exist originally', () => {
+      expect(setting.selectedConnectionId).not.toBeDefined()
+    })
+
+    test('updates when the id changes', async () => {
+      const [connection1, connection2] = await ConnectionModelFactory.createList(2)
+
+      expect(setting.selectedConnectionId).toEqual(connection2.id)
+
+      await connectionStore.setSelectedConnection(connection1)
+
+      expect(setting.selectedConnectionId).toEqual(connection1.id)
+    })
+  })
+
+  describe('Model', () => {
+    test('does not exist originally', () => {
+      expect(setting.selectedModelId).not.toBeDefined()
+    })
+
+    test('updates when the id changes', async () => {
+      const connections = await ConnectionModelFactory.withOptions({
+        connectionParams: { type: 'Ollama' },
+        modelCount: 2,
+      }).createList(2)
+      const models = _.flatMap(connections, 'models')
+
+      expect(setting.selectedModelId).not.toBeDefined()
+
+      // fail if there are duplicate ids
+      expect(_.uniqBy(models, 'id').length).toBe(4)
+
+      //   test each connection/model pair
+      for (const connection of connections) {
+        for (const model of models) {
+          await connectionStore.setSelectedModel(model.id, connection.id)
+
+          expect(connection.id).toBeDefined()
+          expect(model.id).toBeDefined()
+
+          expect(setting).toMatchObject({
+            selectedConnectionId: connection.id,
+            selectedModelId: model.id,
+          })
+        }
+      }
+    })
+  })
+})

--- a/src/tests/helpers/setServerResponseForModels.ts
+++ b/src/tests/helpers/setServerResponseForModels.ts
@@ -1,0 +1,37 @@
+import { setServerResponse } from '~/tests/msw'
+
+import { ConnectionViewModelTypes } from '~/core/connection/viewModels'
+import { BaseModelTypes } from '~/core/connection/types'
+
+export const setServerResponseForModels = (
+  connection: ConnectionViewModelTypes,
+  models: BaseModelTypes[],
+) => {
+  const host = connection.formattedHost
+  let modelUrl: string
+  let response: object = { data: models }
+
+  switch (connection.type) {
+    case 'Ollama':
+      modelUrl = host + '/api/tags'
+      response = { models }
+      break
+
+    case 'LMS':
+    case 'OpenAi':
+      modelUrl = host + '/models'
+      break
+
+    case 'A1111':
+      modelUrl = host + '/sdapi/v1/sd-models'
+      break
+
+    // Gemini
+    default:
+      throw new Error('unsupported model types')
+  }
+
+  setServerResponse(modelUrl, response)
+
+  return host
+}

--- a/src/tests/setupTests.ts
+++ b/src/tests/setupTests.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, beforeAll, afterAll } from 'vitest'
+import { beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest'
 import localforage from 'localforage'
 
 import '@testing-library/jest-dom'
@@ -31,3 +31,15 @@ afterEach(async () => {
 })
 
 afterAll(() => server.close())
+
+vi.mock('~/utils/CachedStorage.ts', () => {
+  return {
+    default: {
+      put: vi.fn().mockResolvedValue(undefined),
+      putResponse: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      move: vi.fn().mockResolvedValue(undefined),
+    },
+  }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ import { pwaPlugins } from './environments/pwa/pwa.vite'
 import { chromePlugins } from './environments/chrome/chrome.vite'
 import { firefoxPlugins } from './environments/firefox/firefox.vite'
 
+const COVERAGE_PERCENTAGE = 50
+
 const replaceOptions = { __DATE__: new Date().toISOString(), __RELOAD_SW__: 'false' }
 
 const isDev = process.env.NODE_ENV === 'development'
@@ -86,5 +88,19 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/core/**'],
+      exclude: ['node_modules', 'dist'],
+      all: true,
+      thresholds: {
+        lines: COVERAGE_PERCENTAGE,
+        functions: COVERAGE_PERCENTAGE,
+        branches: COVERAGE_PERCENTAGE,
+        statements: COVERAGE_PERCENTAGE,
+      },
+    },
   },
 })


### PR DESCRIPTION
Model factories are now set up as so: 

```
const connectionModel = await ConnectionModelFactory.withOptions({
        modelCount: 3,
      }).create({
        type: 'OpenAi',
        host: 'http://openAi-host:4444/v1',
      })
```

the new `withOptions` modifier on the factories allows us to automatically create associations to use (connections -> models, actors -> models, chats -> actors). It should make future integration tests a lot easier to set up and write as well