### PR TITLE
fix: ignore Enter during IME composition

### DIFF
--- a/src/components/ChatBoxInputRow.tsx
+++ b/src/components/ChatBoxInputRow.tsx
@@ -53,7 +53,7 @@ const ChatBoxInputRow = ({ chat, onSend, children }: ChatBoxInputRowProps) => {
   const handleKeyDown = async (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.shiftKey || !textareaRef.current || inputDisabled) return
 
-    if (e.key === 'Enter' && messageContent) {
+    if (e.key === 'Enter' && messageContent && !e.nativeEvent.isComposing) {
       await sendMessage()
 
       textareaRef.current.blur()


### PR DESCRIPTION
Typing Japanese, Chinese or Korean goes through an IME, where the first Enter confirms the current composition candidate rather than submitting. The keydown handler in `ChatBoxInputRow` only checked `e.key === 'Enter' && messageContent`, so that confirming Enter sent the message on a half-finished word.

I added `!e.nativeEvent.isComposing` to the send condition. `nativeEvent` is the underlying DOM `KeyboardEvent`, which exposes `isComposing`; React's synthetic event type doesn't surface it directly, so reading it off `nativeEvent` keeps it type-safe.

Repro: set the OS to a Japanese IME, type something like `かんじ` in the prompt box and press Enter to pick a kanji candidate.
- Before: the message sends on the unfinished text.
- After: that Enter only confirms the candidate; a plain Enter still sends as usual.
